### PR TITLE
Keep cron package

### DIFF
--- a/read-only-fs.sh
+++ b/read-only-fs.sh
@@ -178,12 +178,12 @@ echo "Updating package index files..."
 apt-get update
 
 echo "Removing unwanted packages..."
-#apt-get remove -y --force-yes --purge triggerhappy cron logrotate dbus \
-# dphys-swapfile xserver-common lightdm fake-hwclock
+#apt-get remove -y --force-yes --purge triggerhappy logrotate dbus \
+# dphys-swapfile xserver-common lightdm
 # Let's keep dbus...that includes avahi-daemon, a la 'raspberrypi.local',
 # also keeping xserver & lightdm for GUI login (WIP, not working yet)
-apt-get remove -y --force-yes --purge triggerhappy cron logrotate \
- dphys-swapfile fake-hwclock
+apt-get remove -y --force-yes --purge triggerhappy logrotate \
+ dphys-swapfile
 apt-get -y --force-yes autoremove --purge
 
 # Replace log management with busybox (use logread if needed)


### PR DESCRIPTION
Is there any reason, why cron should be removed? 
I think, for a lot of application it's still a usefull function.

Of course, we should keep fake-hwclock as well, like #4 suggests. Or, if there are any reasons to remove hwclock, then maybe we can install "ntp" instead?